### PR TITLE
Add new functions to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ man:
 
 install: sl man
 	$(INSTALL) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m755 sl $(DESTDIR)$(BINDIR)/sl
+	$(INSTALL) -m755 sl $(DESTDIR)$(BINDIR)
 
 clean:
 	rm -rf sl

--- a/Makefile
+++ b/Makefile
@@ -23,18 +23,19 @@ sl: sl.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
 man:
-	$(INSTALL) -Dm644 sl.1 $(DESTDIR)$(MANDIR)/man1/sl.1
-	$(INSTALL) -Dm644 sl.1.ja $(DESTDIR)$(MANDIR)/ja/man1/sl.1
+	$(INSTALL) -d $(addprefix $(DESTDIR)$(MANDIR)/,man1 ja/man1)
+	$(INSTALL) -m644 sl.1 $(DESTDIR)$(MANDIR)/man1/sl.1
+	$(INSTALL) -m644 sl.1.ja $(DESTDIR)$(MANDIR)/ja/man1/sl.1
 
 install: sl man
-	$(INSTALL) -Dm755 $(DESTDIR)$(BINDIR)/sl
+	$(INSTALL) -d $(DESTDIR)$(BINDIR)
+	$(INSTALL) -m755 sl $(DESTDIR)$(BINDIR)/sl
 
 clean:
-	rm -f sl
+	rm -rf sl
 
 uninstall:
-	rm -f $(DESTDIR)$(BINDIR)/sl
-	rm -f $(DESTDIR)$(MANDIR)/man1/sl.1
-	rm -f $(DESTDIR)$(MANDIR)/ja/man1/sl.1
+	rm -rf $(DESTDIR)$(BINDIR)/sl
+	rm -rf $(addprefix $(DESTDIR)$(MANDIR)/,man1/sl.1 ja/man1/sl.1)
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -3,39 +3,38 @@
 #	Copyright 1993, 1998, 2014, 2019
 #                 Toyoda Masashi
 #		  (mtoyoda@acm.org)
-#	Last Modified: 2022/10/22
+#	Last Modified: 2023/07/08
 #==========================================
-
-CC      ?= cc
-INSTALL ?= install
-CFLAGS  ?= -O3 -Wall
-LDFLAGS ?= -lncurses
 
 PREFIX ?= /usr/local
 BINDIR ?= $(PREFIX)/bin
 MANDIR ?= $(PREFIX)/share/man
 
-.PHONY: all man install clean distclean uninstall
+CFLAGS  ?= -O3 -Wall
+LDFLAGS ?= -lncurses
 
-all: sl
+SRC := $(wildcard *.c)
+BIN := $(SRC:%.c=%)
 
-sl: sl.c
+all: $(BIN)
+
+%: %.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
 
-man:
-	$(INSTALL) -d $(addprefix $(DESTDIR)$(MANDIR)/,man1 ja/man1)
-	$(INSTALL) -m644 sl.1 $(DESTDIR)$(MANDIR)/man1/sl.1
-	$(INSTALL) -m644 sl.1.ja $(DESTDIR)$(MANDIR)/ja/man1/sl.1
+.PHONY: install
 
-install: sl man
-	$(INSTALL) -d $(DESTDIR)$(BINDIR)
-	$(INSTALL) -m755 sl $(DESTDIR)$(BINDIR)
+install: all
+	install -d $(DESTDIR)$(BINDIR)
+	install -d $(addprefix $(DESTDIR)$(MANDIR)/,man1 ja/man1)
+	install -m755 $(BIN) $(DESTDIR)$(BINDIR)
+	install -m644 sl.1 $(DESTDIR)$(MANDIR)/man1
+	install -m644 sl.1.ja $(DESTDIR)$(MANDIR)/ja/man1
+
+.PHONY: clean
 
 clean:
-	rm -rf sl
+	rm -rf $(BIN)
 
-uninstall:
-	rm -rf $(DESTDIR)$(BINDIR)/sl
-	rm -rf $(addprefix $(DESTDIR)$(MANDIR)/,man1/sl.1 ja/man1/sl.1)
+.PHONY: distclean
 
 distclean: clean

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,40 @@
 #==========================================
-#    Makefile: makefile for sl 5.04
+#    Makefile: makefile for sl 5.05
 #	Copyright 1993, 1998, 2014, 2019
 #                 Toyoda Masashi
 #		  (mtoyoda@acm.org)
-#	Last Modified: 2019/03/19
+#	Last Modified: 2022/10/22
 #==========================================
 
-CC=gcc
-CFLAGS=-O3 -Wall
+CC      ?= cc
+INSTALL ?= install
+CFLAGS  ?= -O3 -Wall
+LDFLAGS ?= -lncurses
+
+PREFIX ?= /usr/local
+BINDIR ?= $(PREFIX)/bin
+MANDIR ?= $(PREFIX)/share/man
+
+.PHONY: all man install clean distclean uninstall
 
 all: sl
 
-sl: sl.c sl.h
-	$(CC) $(CFLAGS) -o sl sl.c -lncurses
+sl: sl.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $<
+
+man:
+	$(INSTALL) -Dm644 sl.1 $(DESTDIR)$(MANDIR)/man1/sl.1
+	$(INSTALL) -Dm644 sl.1.ja $(DESTDIR)$(MANDIR)/ja/man1/sl.1
+
+install: sl man
+	$(INSTALL) -Dm755 $(DESTDIR)$(BINDIR)/sl
 
 clean:
 	rm -f sl
+
+uninstall:
+	rm -f $(DESTDIR)$(BINDIR)/sl
+	rm -f $(DESTDIR)$(MANDIR)/man1/sl.1
+	rm -f $(DESTDIR)$(MANDIR)/ja/man1/sl.1
 
 distclean: clean


### PR DESCRIPTION
This PR rewrites the entire Makefile, writing new rules that build and install `sl`, as well as its corresponding manpages. Specific changes were documented under the commit message.